### PR TITLE
Fix panic when value is not presented

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ impl KvStore {
             .await
             .map_err(KvError::from)?
             .as_string()
-            .expect("get request resulted in non-string value");
+            .ok_or(KvError::ValueNotPresented)?;
         Ok(KvValue(inner))
     }
 
@@ -167,6 +167,7 @@ pub enum KvError {
     JavaScript(JsValue),
     Serialization(serde_json::Error),
     InvalidKvStore(String),
+    ValueNotPresented,
 }
 
 impl Into<JsValue> for KvError {
@@ -175,6 +176,7 @@ impl Into<JsValue> for KvError {
             Self::JavaScript(value) => value,
             Self::Serialization(e) => format!("KvError::Serialization: {}", e.to_string()).into(),
             Self::InvalidKvStore(binding) => format!("KvError::InvalidKvStore: {}", binding).into(),
+            Self::ValueNotPresented => "KvError::ValueNotPresented".into(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ impl KvStore {
             .await
             .map_err(KvError::from)?
             .as_string()
-            .ok_or(KvError::ValueNotPresented)?;
+            .expect("get request resulted in non-string value");
         Ok(KvValue(inner))
     }
 
@@ -167,7 +167,6 @@ pub enum KvError {
     JavaScript(JsValue),
     Serialization(serde_json::Error),
     InvalidKvStore(String),
-    ValueNotPresented,
 }
 
 impl Into<JsValue> for KvError {
@@ -176,7 +175,6 @@ impl Into<JsValue> for KvError {
             Self::JavaScript(value) => value,
             Self::Serialization(e) => format!("KvError::Serialization: {}", e.to_string()).into(),
             Self::InvalidKvStore(binding) => format!("KvError::InvalidKvStore: {}", binding).into(),
-            Self::ValueNotPresented => "KvError::ValueNotPresented".into(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,15 +58,15 @@ impl KvStore {
     }
 
     /// Fetches the value from the kv store by name.
-    pub async fn get(&self, name: &str) -> Result<KvValue, KvError> {
+    pub async fn get(&self, name: &str) -> Result<Option<KvValue>, KvError> {
         let name = JsValue::from(name);
         let promise: Promise = self.get_function.call1(&self.this, &name)?.into();
         let inner = JsFuture::from(promise)
             .await
             .map_err(KvError::from)?
             .as_string()
-            .expect("get request resulted in non-string value");
-        Ok(KvValue(inner))
+            .map(KvValue);
+        Ok(inner)
     }
 
     /// Fetches the value and associated metadata from the kv store by name.


### PR DESCRIPTION
Hey

Method `get` panics when the value is not represented in the KV. I think it would be better to return an error that could be handled.