### PR TITLE
chore: fix a few clippy warnings

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -8,6 +8,7 @@ use crate::{KvError, ListResponse};
 
 /// A builder to configure put requests.
 #[derive(Debug, Clone, Serialize)]
+#[must_use = "PutOptionsBuilder does nothing until you 'execute' it"]
 pub struct PutOptionsBuilder {
     #[serde(skip)]
     pub(crate) this: Object,
@@ -59,6 +60,7 @@ impl PutOptionsBuilder {
 
 /// A builder to configure list requests.
 #[derive(Debug, Clone, Serialize)]
+#[must_use = "ListOptionsBuilder does nothing until you 'execute' it"]
 pub struct ListOptionsBuilder {
     #[serde(skip)]
     pub(crate) this: Object,
@@ -105,6 +107,7 @@ impl ListOptionsBuilder {
 
 /// A builder to configure get requests.
 #[derive(Debug, Clone, Serialize)]
+#[must_use = "GetOptionsBuilder does nothing until you 'get' it"]
 pub struct GetOptionsBuilder {
     #[serde(skip)]
     pub(crate) this: Object,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,9 +178,7 @@ impl From<KvError> for JsValue {
     fn from(val: KvError) -> Self {
         match val {
             KvError::JavaScript(value) => value,
-            KvError::Serialization(e) => {
-                format!("KvError::Serialization: {}", e.to_string()).into()
-            }
+            KvError::Serialization(e) => format!("KvError::Serialization: {}", e).into(),
             KvError::InvalidKvStore(binding) => {
                 format!("KvError::InvalidKvStore: {}", binding).into()
             }
@@ -215,7 +213,7 @@ impl<T: Serialize> ToRawKvValue for T {
     fn raw_kv_value(&self) -> Result<JsValue, KvError> {
         let value = JsValue::from_serde(self)?;
 
-        if let Some(_) = value.as_string() {
+        if value.as_string().is_some() {
             Ok(value)
         } else if let Some(number) = value.as_f64() {
             Ok(JsValue::from(number.to_string()))


### PR DESCRIPTION
This will fix the few clippy warnings in the project:

[https://rust-lang.github.io/rust-clippy/master/index.html#return_self_not_must_use](https://rust-lang.github.io/rust-clippy/master/index.html#return_self_not_must_use)
[https://rust-lang.github.io/rust-clippy/master/index.html#to_string_in_format_args](https://rust-lang.github.io/rust-clippy/master/index.html#to_string_in_format_args)
[https://rust-lang.github.io/rust-clippy/master/index.html#redundant_pattern_matching](https://rust-lang.github.io/rust-clippy/master/index.html#redundant_pattern_matching)

Thanks!