### PR TITLE
Fixed cyclic reference in cargo.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,9 @@ js-sys = "0.3.50"
 serde = { version = "1.0.125", features = ["derive"] }
 serde_json = "1.0.64"
 thiserror = "1.0.29"
-wasm-bindgen = { version = "0.2.73", features = ["serde-serialize"] }
+wasm-bindgen = { version = "0.2.73" }
 wasm-bindgen-futures = "0.4.23"
+serde-wasm-bindgen = "0.4.3"
 
 [dev-dependencies]
 fs_extra = "1.2.0"

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -46,7 +46,7 @@ impl PutOptionsBuilder {
     }
     /// Puts the value in the kv store.
     pub async fn execute(self) -> Result<(), KvError> {
-        let options_object = JsValue::from_serde(&self)?;
+        let options_object = serde_wasm_bindgen::to_value(&self)?;
         let promise: Promise = self
             .put_function
             .call3(&self.this, &self.name, &self.value, &options_object)?
@@ -93,14 +93,13 @@ impl ListOptionsBuilder {
     }
     /// Lists the key value pairs in the kv store.
     pub async fn execute(self) -> Result<ListResponse, KvError> {
-        let options_object = JsValue::from_serde(&self)?;
+        let options_object = serde_wasm_bindgen::to_value(&self)?;
         let promise: Promise = self
             .list_function
             .call1(&self.this, &options_object)?
             .into();
-        JsFuture::from(promise)
-            .await?
-            .into_serde()
+        serde_wasm_bindgen::from_value(JsFuture::from(promise)
+            .await?)
             .map_err(KvError::from)
     }
 }
@@ -142,12 +141,12 @@ impl GetOptionsBuilder {
     }
 
     async fn get(self) -> Result<JsValue, KvError> {
-        let options_object = JsValue::from_serde(&self)?;
+        let options_object = serde_wasm_bindgen::to_value(&self)?;
         let promise: Promise = self
             .get_function
             .call2(&self.this, &self.name, &options_object)?
             .into();
-        Ok(JsFuture::from(promise).await.map_err(KvError::from)?)
+        JsFuture::from(promise).await.map_err(KvError::from)
     }
 
     /// Gets the value as a string.
@@ -165,7 +164,7 @@ impl GetOptionsBuilder {
         Ok(if value.is_null() {
             None
         } else {
-            Some(value.into_serde().map_err(KvError::from)?)
+            Some(serde_wasm_bindgen::from_value(value).map_err(KvError::from)?)
         })
     }
 
@@ -185,7 +184,7 @@ impl GetOptionsBuilder {
     where
         M: DeserializeOwned,
     {
-        let options_object = JsValue::from_serde(&self)?;
+        let options_object = serde_wasm_bindgen::to_value(&self)?;
         let promise: Promise = self
             .get_with_meta_function
             .call2(&self.this, &self.name, &options_object)?
@@ -200,7 +199,7 @@ impl GetOptionsBuilder {
             if metadata.is_null() {
                 None
             } else {
-                Some(metadata.into_serde().map_err(KvError::from)?)
+                Some(serde_wasm_bindgen::from_value(metadata).map_err(KvError::from)?)
             },
         ))
     }
@@ -231,7 +230,7 @@ impl GetOptionsBuilder {
             if value.is_null() {
                 None
             } else {
-                Some(value.into_serde().map_err(KvError::from)?)
+                Some(serde_wasm_bindgen::from_value(value).map_err(KvError::from)?)
             },
             metadata,
         ))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,6 +168,8 @@ pub enum KvError {
     JavaScript(JsValue),
     #[error("unable to serialize/deserialize: {0}")]
     Serialization(serde_json::Error),
+    #[error("unable to serialize/deserialize: {0}")]
+    SerializationBindgen(serde_wasm_bindgen::Error),
     #[error("invalid kv store: {0}")]
     InvalidKvStore(String),
 }
@@ -177,6 +179,7 @@ impl From<KvError> for JsValue {
         match val {
             KvError::JavaScript(value) => value,
             KvError::Serialization(e) => format!("KvError::Serialization: {}", e).into(),
+            KvError::SerializationBindgen(e) => format!("KvError::SerializationBindgen: {}", e).into(),
             KvError::InvalidKvStore(binding) => {
                 format!("KvError::InvalidKvStore: {}", binding).into()
             }
@@ -196,6 +199,12 @@ impl From<serde_json::Error> for KvError {
     }
 }
 
+impl From<serde_wasm_bindgen::Error> for KvError {
+    fn from(value: serde_wasm_bindgen::Error) -> Self {
+        Self::SerializationBindgen(value)
+    }
+}
+
 /// A trait for things that can be converted to [`wasm_bindgen::JsValue`] to be passed to the kv.
 pub trait ToRawKvValue {
     fn raw_kv_value(&self) -> Result<JsValue, KvError>;
@@ -209,7 +218,7 @@ impl ToRawKvValue for str {
 
 impl<T: Serialize> ToRawKvValue for T {
     fn raw_kv_value(&self) -> Result<JsValue, KvError> {
-        let value = JsValue::from_serde(self)?;
+        let value = serde_wasm_bindgen::to_value(self)?;
 
         if value.as_string().is_some() {
             Ok(value)


### PR DESCRIPTION
This changes worker to use serde-wasm-bindgen package, rather than relying on the deprecated serde option in wasm-bindgen.

Description of the cyclic reference issue that I was hitting is here:
https://github.com/tkaitchuck/aHash/issues/95

wasm_bindgen::JsValue::from_serde and wasm_bindgen::JsValue::into_serde are deprecated here (citing the cyclic reference issue that I encountered).
https://github.com/rustwasm/wasm-bindgen/pull/3031

Also, additional description of serde-wasm-bindgen is found here (turns out that it was written by Cloudflare).
https://github.com/rustwasm/wasm-bindgen/issues/1258

This patch replaces the usage of wasm_bindgen::JsValue::from_serde and wasm_bindgen::JsValue::into_serde with serde_wasm_bindgen::from_value() and serde_wasm_bindgen::to_value() equivalents..