### PR TITLE
Use gloo_utils instead of the serde feature in wasm_bindgen to convert objects.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,9 @@ js-sys = "0.3.50"
 serde = { version = "1.0.125", features = ["derive"] }
 serde_json = "1.0.64"
 thiserror = "1.0.29"
-wasm-bindgen = { version = "0.2.73", features = ["serde-serialize"] }
+wasm-bindgen = "0.2.73"
 wasm-bindgen-futures = "0.4.23"
+gloo-utils = { version = "0.1.5", features = ["serde"] }
 
 [dev-dependencies]
 fs_extra = "1.2.0"

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -3,6 +3,7 @@ use serde::{de::DeserializeOwned, Serialize};
 use serde_json::Value;
 use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_futures::JsFuture;
+use gloo_utils::format::JsValueSerdeExt;
 
 use crate::{KvError, ListResponse};
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,9 +1,9 @@
+use gloo_utils::format::JsValueSerdeExt;
 use js_sys::{ArrayBuffer, Function, Object, Promise, Uint8Array};
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::Value;
 use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_futures::JsFuture;
-use gloo_utils::format::JsValueSerdeExt;
 
 use crate::{KvError, ListResponse};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,12 +20,12 @@ mod builder;
 
 pub use builder::*;
 
+use gloo_utils::format::JsValueSerdeExt;
 use js_sys::{global, Function, Object, Promise, Reflect, Uint8Array};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use wasm_bindgen::JsValue;
 use wasm_bindgen_futures::JsFuture;
-use gloo_utils::format::JsValueSerdeExt;
 
 /// A binding to a Cloudflare KvStore.
 #[derive(Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use wasm_bindgen::JsValue;
 use wasm_bindgen_futures::JsFuture;
+use gloo_utils::format::JsValueSerdeExt;
 
 /// A binding to a Cloudflare KvStore.
 #[derive(Clone)]


### PR DESCRIPTION
This changes worker to use gloo_utils package, rather than relying on the deprecated serde option in wasm-bindgen.

Description of the cyclic reference issue that I was hitting is here:
https://github.com/tkaitchuck/aHash/issues/95

wasm_bindgen::JsValue::from_serde and wasm_bindgen::JsValue::into_serde are deprecated here (citing the cyclic reference issue that I encountered).
https://github.com/rustwasm/wasm-bindgen/pull/3031

This patch replaces the usage of wasm_bindgen::JsValue::from_serde and wasm_bindgen::JsValue::into_serde with gloo_utils::format::JsValueSerdeExt::from_serde and gloo_utils::format::JsValueSerdeExt::into_serde respectively.