### PR TITLE
refactor: use serde-wasm-bindgen instead of gloo-utils

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,16 @@ serde_json = "1.0.64"
 thiserror = "1.0.29"
 wasm-bindgen = "0.2.84"
 wasm-bindgen-futures = "0.4.23"
-gloo-utils = { version = "0.1.5", features = ["serde"] }
+serde-wasm-bindgen = "0.5.0"
 
 [dev-dependencies]
 fs_extra = "1.2.0"
 psutil = { git = "https://github.com/mygnu/rust-psutil", branch = "update-dependencies" }
 reqwest = { version = "0.11.8", features = ["json"] }
-tokio = { version = "1.5.0", features = ["rt", "macros", "rt-multi-thread", "test-util", "time"] }
+tokio = { version = "1.5.0", features = [
+    "rt",
+    "macros",
+    "rt-multi-thread",
+    "test-util",
+    "time",
+] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,6 @@ mod builder;
 
 pub use builder::*;
 
-use gloo_utils::format::JsValueSerdeExt;
 use js_sys::{global, Function, Object, Promise, Reflect, Uint8Array};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -177,9 +176,9 @@ impl From<KvError> for JsValue {
     fn from(val: KvError) -> Self {
         match val {
             KvError::JavaScript(value) => value,
-            KvError::Serialization(e) => format!("KvError::Serialization: {}", e).into(),
+            KvError::Serialization(e) => format!("KvError::Serialization: {e}").into(),
             KvError::InvalidKvStore(binding) => {
-                format!("KvError::InvalidKvStore: {}", binding).into()
+                format!("KvError::InvalidKvStore: {binding}").into()
             }
         }
     }
@@ -210,7 +209,7 @@ impl ToRawKvValue for str {
 
 impl<T: Serialize> ToRawKvValue for T {
     fn raw_kv_value(&self) -> Result<JsValue, KvError> {
-        let value = JsValue::from_serde(self)?;
+        let value = serde_wasm_bindgen::to_value(self).map_err(JsValue::from)?;
 
         if value.as_string().is_some() {
             Ok(value)


### PR DESCRIPTION
worker-kv went with `gloo-utils` for `serde` serialization to JS objects but worker-rs opted to go with `serde-wasm-bindgen`. It is preferable for worker-kv to stay inline with workers-rs.