### PR TITLE
fix: use json compatible serializer

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -46,7 +46,9 @@ impl PutOptionsBuilder {
     }
     /// Puts the value in the kv store.
     pub async fn execute(self) -> Result<(), KvError> {
-        let options_object = serde_wasm_bindgen::to_value(&self).map_err(JsValue::from)?;
+        let options_object = self
+            .serialize(&serde_wasm_bindgen::Serializer::json_compatible())
+            .map_err(JsValue::from)?;
         let promise: Promise = self
             .put_function
             .call3(&self.this, &self.name, &self.value, &options_object)?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,7 +209,9 @@ impl ToRawKvValue for str {
 
 impl<T: Serialize> ToRawKvValue for T {
     fn raw_kv_value(&self) -> Result<JsValue, KvError> {
-        let value = serde_wasm_bindgen::to_value(self).map_err(JsValue::from)?;
+        let value = self
+            .serialize(&serde_wasm_bindgen::Serializer::json_compatible())
+            .map_err(JsValue::from)?;
 
         if value.as_string().is_some() {
             Ok(value)


### PR DESCRIPTION
If you set named struct to metadata, it will be serialized to JS Map and not written to KV. changing to JSON compatible serialization will fix this issue.