### PR TITLE
impl Send/Sync for KvStore

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,9 @@ pub struct KvStore {
     pub(crate) delete_function: Function,
 }
 
+unsafe impl Send for KvStore {}
+unsafe impl Sync for KvStore {}
+
 impl KvStore {
     /// Creates a new [`KvStore`] with the binding specified in your `wrangler.toml`.
     pub fn create(binding: &str) -> Result<Self, KvError> {


### PR DESCRIPTION
This is needed to allow attaching `KvStore` to the `axum` router. This is safe because we know that these type will never be moved to another thread in the context of the worker runtime.